### PR TITLE
Fix Vulkan on macOS and upgrade build.zig to zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,12 +3,12 @@ const std = @import("std");
 const targets: []const std.Target.Query = &.{
 	// NB: some of these targets don't build yet in Cubyz, but are
 	// included for completion's sake
-	.{ .cpu_arch = .aarch64, .os_tag = .macos },
-	.{ .cpu_arch = .aarch64, .os_tag = .linux },
-	.{ .cpu_arch = .aarch64, .os_tag = .windows },
-	.{ .cpu_arch = .x86_64, .os_tag = .macos },
-	.{ .cpu_arch = .x86_64, .os_tag = .linux },
-	.{ .cpu_arch = .x86_64, .os_tag = .windows },
+	.{.cpu_arch = .aarch64, .os_tag = .macos},
+	.{.cpu_arch = .aarch64, .os_tag = .linux},
+	.{.cpu_arch = .aarch64, .os_tag = .windows},
+	.{.cpu_arch = .x86_64, .os_tag = .macos},
+	.{.cpu_arch = .x86_64, .os_tag = .linux},
+	.{.cpu_arch = .x86_64, .os_tag = .windows},
 };
 
 fn addPackageCSourceFiles(exe: *std.Build.Step.Compile, dep: *std.Build.Dependency, files: []const []const u8, flags: []const []const u8) void {
@@ -70,22 +70,7 @@ pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Buil
 
 	// NOTE(blackedout): How to compile the Vulkan loader is taken from the CMakeLists of that project.
 	// This zig build is very incomplete but somehow still works on macOS
-	const normalLoaderSources = [_][]const u8{
-		"allocation.c",
-		"cJSON.c",
-		"debug_utils.c",
-		"extension_manual.c",
-		"loader_environment.c",
-		"gpa_helper.c",
-		"loader.c",
-		"log.c",
-		"loader_json.c",
-		"settings.c",
-		"terminator.c",
-		"trampoline.c",
-		"unknown_function_handling.c",
-		"wsi.c"
-	};
+	const normalLoaderSources = [_][]const u8{"allocation.c", "cJSON.c", "debug_utils.c", "extension_manual.c", "loader_environment.c", "gpa_helper.c", "loader.c", "log.c", "loader_json.c", "settings.c", "terminator.c", "trampoline.c", "unknown_function_handling.c", "wsi.c"};
 
 	const win32LoaderSources = [_][]const u8{
 		"loader_windows.c",
@@ -102,8 +87,7 @@ pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Buil
 		.windows => {
 			all_flags.append("-DVK_USE_PLATFORM_WIN32_KHR") catch unreachable;
 		},
-		.linux, .freebsd, .openbsd, .dragonfly => {
-		},
+		.linux, .freebsd, .openbsd, .dragonfly => {},
 		.ios => {
 			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
 			all_flags.append("-VK_USE_PLATFORM_IOS_MVK") catch unreachable;
@@ -112,7 +96,7 @@ pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Buil
 			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
 			all_flags.append("-DVK_USE_PLATFORM_MACOS_MVK") catch unreachable;
 		},
-		else => {}
+		else => {},
 	}
 	all_flags.append("-DVK_ENABLE_BETA_EXTENSIONS") catch unreachable;
 
@@ -127,17 +111,28 @@ pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Buil
 	c_lib.addIncludePath(loader.path("loader"));
 	c_lib.addIncludePath(loader.path("loader/generated"));
 	c_lib.installHeadersDirectory(headers.path("include"), "", .{});
-	c_lib.addCSourceFiles(.{ .root = loader.path("loader"), .files = &normalLoaderSources, .flags = all_flags.items, });
+	c_lib.addCSourceFiles(.{
+		.root = loader.path("loader"),
+		.files = &normalLoaderSources,
+		.flags = all_flags.items,
+	});
 	switch(target.result.os.tag) {
 		.windows => {
-			c_lib.addCSourceFiles(.{ .root = loader.path("loader"), .files = &win32LoaderSources, .flags = all_flags.items, });
+			c_lib.addCSourceFiles(.{
+				.root = loader.path("loader"),
+				.files = &win32LoaderSources,
+				.flags = all_flags.items,
+			});
 		},
 		.linux, .freebsd, .openbsd, .dragonfly => {
-			c_lib.addCSourceFiles(.{ .root = loader.path("loader"), .files = &linuxLoaderSources, .flags = all_flags.items, });
+			c_lib.addCSourceFiles(.{
+				.root = loader.path("loader"),
+				.files = &linuxLoaderSources,
+				.flags = all_flags.items,
+			});
 		},
-		.macos => {
-		},
-		else => {}
+		.macos => {},
+		else => {},
 	}
 
 	// NOTE(blackedout): Add the MoltenVK binary and JSON manifest file
@@ -151,14 +146,10 @@ pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Buil
 }
 
 pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, flags: []const []const u8) *std.Build.Step.InstallArtifact {
-	const layerslib = b.addLibrary(.{
-		.name = "VkLayer_khronos_validation",
-		.root_module = b.createModule(.{
-			.target = target,
-			.optimize = optimize,
-		}),
-		.linkage = .dynamic
-	});
+	const layerslib = b.addLibrary(.{.name = "VkLayer_khronos_validation", .root_module = b.createModule(.{
+		.target = target,
+		.optimize = optimize,
+	}), .linkage = .dynamic});
 
 	const headers = b.dependency("Vulkan-Headers", .{});
 	const validationLayers = b.dependency("Vulkan-ValidationLayers", .{});
@@ -166,208 +157,9 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 
 	// NOTE(blackedout): How to compile the Vulkan validation layers is taken from the CMakeLists of that project.
 	// This zig build is very incomplete but somehow still works on macOS
-	const layerSources = [_][]const u8{
-		"error_message/logging.cpp",
-		"error_message/error_location.cpp",
-		"vulkan/generated/error_location_helper.cpp",
-		"vulkan/generated/feature_requirements_helper.cpp",
-		"vulkan/generated/pnext_chain_extraction.cpp",
-		"vulkan/generated/vk_function_pointers.cpp",
-		"vulkan/generated/vk_dispatch_table_helper.cpp",
-		"vulkan/generated/vk_object_types.cpp",
-		"vulkan/generated/vk_extension_helper.cpp",
-		"utils/convert_utils.cpp",
-		"utils/dispatch_utils.cpp",
-		"utils/file_system_utils.cpp",
-		"utils/hash_util.cpp",
-		"utils/image_utils.cpp",
-		"utils/image_layout_utils.cpp",
-		"utils/vk_layer_extension_utils.cpp",
-		"utils/keyboard.cpp",
-		"utils/ray_tracing_utils.cpp",
-		"utils/sync_utils.cpp",
-		"utils/text_utils.cpp",
-		"utils/vk_struct_compare.cpp",
-		"vk_layer_config.cpp",
+	const layerSources = [_][]const u8{"error_message/logging.cpp", "error_message/error_location.cpp", "vulkan/generated/error_location_helper.cpp", "vulkan/generated/feature_requirements_helper.cpp", "vulkan/generated/pnext_chain_extraction.cpp", "vulkan/generated/vk_function_pointers.cpp", "vulkan/generated/vk_dispatch_table_helper.cpp", "vulkan/generated/vk_object_types.cpp", "vulkan/generated/vk_extension_helper.cpp", "utils/convert_utils.cpp", "utils/dispatch_utils.cpp", "utils/file_system_utils.cpp", "utils/hash_util.cpp", "utils/image_utils.cpp", "utils/image_layout_utils.cpp", "utils/vk_layer_extension_utils.cpp", "utils/keyboard.cpp", "utils/ray_tracing_utils.cpp", "utils/sync_utils.cpp", "utils/text_utils.cpp", "utils/vk_struct_compare.cpp", "vk_layer_config.cpp", "best_practices/bp_buffer.cpp", "best_practices/bp_cmd_buffer.cpp", "best_practices/bp_cmd_buffer_nv.cpp", "best_practices/bp_copy_blit_resolve.cpp", "best_practices/bp_descriptor.cpp", "best_practices/bp_device_memory.cpp", "best_practices/bp_drawdispatch.cpp", "best_practices/bp_framebuffer.cpp", "best_practices/bp_image.cpp", "best_practices/bp_instance_device.cpp", "best_practices/bp_pipeline.cpp", "best_practices/bp_ray_tracing.cpp", "best_practices/bp_render_pass.cpp", "best_practices/bp_state_tracker.cpp", "best_practices/bp_state.cpp", "best_practices/bp_synchronization.cpp", "best_practices/bp_utils.cpp", "best_practices/bp_video.cpp", "best_practices/bp_wsi.cpp", "chassis/chassis_manual.cpp", "chassis/dispatch_object_manual.cpp", "containers/subresource_adapter.cpp", "core_checks/cc_android.cpp", "core_checks/cc_buffer.cpp", "core_checks/cc_cmd_buffer_dynamic.cpp", "core_checks/cc_cmd_buffer.cpp", "core_checks/cc_copy_blit_resolve.cpp", "core_checks/cc_data_graph.cpp", "core_checks/cc_descriptor.cpp", "core_checks/cc_device.cpp", "core_checks/cc_device_memory.cpp", "core_checks/cc_device_generated_commands.cpp", "core_checks/cc_drawdispatch.cpp", "core_checks/cc_external_object.cpp", "core_checks/cc_image.cpp", "core_checks/cc_image_layout.cpp", "core_checks/cc_pipeline_compute.cpp", "core_checks/cc_pipeline_graphics.cpp", "core_checks/cc_pipeline_ray_tracing.cpp", "core_checks/cc_pipeline.cpp", "core_checks/cc_query.cpp", "core_checks/cc_queue.cpp", "core_checks/cc_ray_tracing.cpp", "core_checks/cc_render_pass.cpp", "core_checks/cc_spirv.cpp", "core_checks/cc_shader_interface.cpp", "core_checks/cc_shader_object.cpp", "core_checks/cc_state_tracker.cpp", "core_checks/cc_submit.cpp", "core_checks/cc_sync_vuid_maps.cpp", "core_checks/cc_synchronization.cpp", "core_checks/cc_tensor.cpp", "core_checks/cc_video.cpp", "core_checks/cc_vuid_maps.cpp", "core_checks/cc_wsi.cpp", "core_checks/cc_ycbcr.cpp", "drawdispatch/descriptor_validator.cpp", "drawdispatch/drawdispatch_vuids.cpp", "error_message/spirv_logging.cpp", "external/vma/vma.cpp", "vulkan/generated/best_practices.cpp", "vulkan/generated/chassis.cpp", "vulkan/generated/valid_enum_values.cpp", "vulkan/generated/valid_flag_values.cpp", "vulkan/generated/command_validation.cpp", "vulkan/generated/deprecation.cpp", "vulkan/generated/device_features.cpp", "vulkan/generated/dynamic_state_helper.cpp", "vulkan/generated/feature_not_present.cpp", "vulkan/generated/dispatch_vector.cpp", "vulkan/generated/dispatch_object.cpp", "vulkan/generated/validation_object.cpp", "vulkan/generated/object_tracker.cpp", "vulkan/generated/spirv_grammar_helper.cpp", "vulkan/generated/spirv_validation_helper.cpp", "vulkan/generated/stateless_validation_helper.cpp", "vulkan/generated/sync_validation_types.cpp", "vulkan/generated/thread_safety.cpp", "vulkan/generated/gpuav_offline_spirv.cpp", "gpuav/core/gpuav_features.cpp", "gpuav/core/gpuav_record.cpp", "gpuav/core/gpuav_setup.cpp", "gpuav/core/gpuav_settings.cpp", "gpuav/core/gpuav_validation_pipeline.cpp", "gpuav/validation_cmd/gpuav_validation_cmd_common.cpp", "gpuav/validation_cmd/gpuav_draw.cpp", "gpuav/validation_cmd/gpuav_dispatch.cpp", "gpuav/validation_cmd/gpuav_trace_rays.cpp", "gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp", "gpuav/descriptor_validation/gpuav_descriptor_validation.cpp", "gpuav/descriptor_validation/gpuav_descriptor_set.cpp", "gpuav/debug_printf/debug_printf.cpp", "gpuav/error_message/gpuav_vuids.cpp", "gpuav/instrumentation/gpuav_shader_instrumentor.cpp", "gpuav/instrumentation/gpuav_instrumentation.cpp", "gpuav/instrumentation/buffer_device_address.cpp", "gpuav/instrumentation/descriptor_checks.cpp", "gpuav/instrumentation/post_process_descriptor_indexing.cpp", "gpuav/resources/gpuav_state_trackers.cpp", "gpuav/resources/gpuav_vulkan_objects.cpp", "object_tracker/object_tracker_utils.cpp", "state_tracker/buffer_state.cpp", "state_tracker/cmd_buffer_state.cpp", "state_tracker/data_graph_pipeline_session_state.cpp", "state_tracker/descriptor_sets.cpp", "state_tracker/device_generated_commands_state.cpp", "state_tracker/device_memory_state.cpp", "state_tracker/device_state.cpp", "state_tracker/fence_state.cpp", "state_tracker/image_layout_map.cpp", "state_tracker/image_state.cpp", "state_tracker/last_bound_state.cpp", "state_tracker/pipeline_layout_state.cpp", "state_tracker/pipeline_state.cpp", "state_tracker/pipeline_library_state.cpp", "state_tracker/semaphore_state.cpp", "state_tracker/state_object.cpp", "state_tracker/query_state.cpp", "state_tracker/tensor_state.cpp", "state_tracker/queue_state.cpp", "state_tracker/render_pass_state.cpp", "state_tracker/shader_instruction.cpp", "state_tracker/shader_module.cpp", "state_tracker/shader_object_state.cpp", "state_tracker/shader_stage_state.cpp", "state_tracker/state_tracker.cpp", "state_tracker/video_session_state.cpp", "state_tracker/wsi_state.cpp", "stateless/sl_buffer.cpp", "stateless/sl_cmd_buffer_dynamic.cpp", "stateless/sl_cmd_buffer.cpp", "stateless/sl_descriptor.cpp", "stateless/sl_device_generated_commands.cpp", "stateless/sl_device_memory.cpp", "stateless/sl_external_object.cpp", "stateless/sl_framebuffer.cpp", "stateless/sl_image.cpp", "stateless/sl_instance_device.cpp", "stateless/sl_pipeline.cpp", "stateless/sl_ray_tracing.cpp", "stateless/sl_render_pass.cpp", "stateless/sl_shader_object.cpp", "stateless/sl_spirv.cpp", "stateless/sl_synchronization.cpp", "stateless/sl_tensor.cpp", "stateless/sl_utils.cpp", "stateless/sl_vuid_maps.cpp", "stateless/sl_wsi.cpp", "sync/sync_access_context.cpp", "sync/sync_access_state.cpp", "sync/sync_barrier.cpp", "sync/sync_commandbuffer.cpp", "sync/sync_common.cpp", "sync/sync_error_messages.cpp", "sync/sync_image.cpp", "sync/sync_op.cpp", "sync/sync_renderpass.cpp", "sync/sync_reporting.cpp", "sync/sync_stats.cpp", "sync/sync_submit.cpp", "sync/sync_validation.cpp", "thread_tracker/thread_safety_validation.cpp", "utils/shader_utils.cpp", "layer_options.cpp"};
 
-		"best_practices/bp_buffer.cpp",
-		"best_practices/bp_cmd_buffer.cpp",
-		"best_practices/bp_cmd_buffer_nv.cpp",
-		"best_practices/bp_copy_blit_resolve.cpp",
-		"best_practices/bp_descriptor.cpp",
-		"best_practices/bp_device_memory.cpp",
-		"best_practices/bp_drawdispatch.cpp",
-		"best_practices/bp_framebuffer.cpp",
-		"best_practices/bp_image.cpp",
-		"best_practices/bp_instance_device.cpp",
-		"best_practices/bp_pipeline.cpp",
-		"best_practices/bp_ray_tracing.cpp",
-		"best_practices/bp_render_pass.cpp",
-		"best_practices/bp_state_tracker.cpp",
-		"best_practices/bp_state.cpp",
-		"best_practices/bp_synchronization.cpp",
-		"best_practices/bp_utils.cpp",
-		"best_practices/bp_video.cpp",
-		"best_practices/bp_wsi.cpp",
-		"chassis/chassis_manual.cpp",
-		"chassis/dispatch_object_manual.cpp",
-		"containers/subresource_adapter.cpp",
-		"core_checks/cc_android.cpp",
-		"core_checks/cc_buffer.cpp",
-		"core_checks/cc_cmd_buffer_dynamic.cpp",
-		"core_checks/cc_cmd_buffer.cpp",
-		"core_checks/cc_copy_blit_resolve.cpp",
-		"core_checks/cc_data_graph.cpp",
-		"core_checks/cc_descriptor.cpp",
-		"core_checks/cc_device.cpp",
-		"core_checks/cc_device_memory.cpp",
-		"core_checks/cc_device_generated_commands.cpp",
-		"core_checks/cc_drawdispatch.cpp",
-		"core_checks/cc_external_object.cpp",
-		"core_checks/cc_image.cpp",
-		"core_checks/cc_image_layout.cpp",
-		"core_checks/cc_pipeline_compute.cpp",
-		"core_checks/cc_pipeline_graphics.cpp",
-		"core_checks/cc_pipeline_ray_tracing.cpp",
-		"core_checks/cc_pipeline.cpp",
-		"core_checks/cc_query.cpp",
-		"core_checks/cc_queue.cpp",
-		"core_checks/cc_ray_tracing.cpp",
-		"core_checks/cc_render_pass.cpp",
-		"core_checks/cc_spirv.cpp",
-		"core_checks/cc_shader_interface.cpp",
-		"core_checks/cc_shader_object.cpp",
-		"core_checks/cc_state_tracker.cpp",
-		"core_checks/cc_submit.cpp",
-		"core_checks/cc_sync_vuid_maps.cpp",
-		"core_checks/cc_synchronization.cpp",
-		"core_checks/cc_tensor.cpp",
-		"core_checks/cc_video.cpp",
-		"core_checks/cc_vuid_maps.cpp",
-		"core_checks/cc_wsi.cpp",
-		"core_checks/cc_ycbcr.cpp",
-		"drawdispatch/descriptor_validator.cpp",
-		"drawdispatch/drawdispatch_vuids.cpp",
-		"error_message/spirv_logging.cpp",
-		"external/vma/vma.cpp",
-		"vulkan/generated/best_practices.cpp",
-		"vulkan/generated/chassis.cpp",
-		"vulkan/generated/valid_enum_values.cpp",
-		"vulkan/generated/valid_flag_values.cpp",
-		"vulkan/generated/command_validation.cpp",
-		"vulkan/generated/deprecation.cpp",
-		"vulkan/generated/device_features.cpp",
-		"vulkan/generated/dynamic_state_helper.cpp",
-		"vulkan/generated/feature_not_present.cpp",
-		"vulkan/generated/dispatch_vector.cpp",
-		"vulkan/generated/dispatch_object.cpp",
-		"vulkan/generated/validation_object.cpp",
-		"vulkan/generated/object_tracker.cpp",
-		"vulkan/generated/spirv_grammar_helper.cpp",
-		"vulkan/generated/spirv_validation_helper.cpp",
-		"vulkan/generated/stateless_validation_helper.cpp",
-		"vulkan/generated/sync_validation_types.cpp",
-		"vulkan/generated/thread_safety.cpp",
-		"vulkan/generated/gpuav_offline_spirv.cpp",
-		"gpuav/core/gpuav_features.cpp",
-		"gpuav/core/gpuav_record.cpp",
-		"gpuav/core/gpuav_setup.cpp",
-		"gpuav/core/gpuav_settings.cpp",
-		"gpuav/core/gpuav_validation_pipeline.cpp",
-		"gpuav/validation_cmd/gpuav_validation_cmd_common.cpp",
-		"gpuav/validation_cmd/gpuav_draw.cpp",
-		"gpuav/validation_cmd/gpuav_dispatch.cpp",
-		"gpuav/validation_cmd/gpuav_trace_rays.cpp",
-		"gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp",
-		"gpuav/descriptor_validation/gpuav_descriptor_validation.cpp",
-		"gpuav/descriptor_validation/gpuav_descriptor_set.cpp",
-		"gpuav/debug_printf/debug_printf.cpp",
-		"gpuav/error_message/gpuav_vuids.cpp",
-		"gpuav/instrumentation/gpuav_shader_instrumentor.cpp",
-		"gpuav/instrumentation/gpuav_instrumentation.cpp",
-		"gpuav/instrumentation/buffer_device_address.cpp",
-		"gpuav/instrumentation/descriptor_checks.cpp",
-		"gpuav/instrumentation/post_process_descriptor_indexing.cpp",
-		"gpuav/resources/gpuav_state_trackers.cpp",
-		"gpuav/resources/gpuav_vulkan_objects.cpp",
-		"object_tracker/object_tracker_utils.cpp",
-		"state_tracker/buffer_state.cpp",
-		"state_tracker/cmd_buffer_state.cpp",
-		"state_tracker/data_graph_pipeline_session_state.cpp",
-		"state_tracker/descriptor_sets.cpp",
-		"state_tracker/device_generated_commands_state.cpp",
-		"state_tracker/device_memory_state.cpp",
-		"state_tracker/device_state.cpp",
-		"state_tracker/fence_state.cpp",
-		"state_tracker/image_layout_map.cpp",
-		"state_tracker/image_state.cpp",
-		"state_tracker/last_bound_state.cpp",
-		"state_tracker/pipeline_layout_state.cpp",
-		"state_tracker/pipeline_state.cpp",
-		"state_tracker/pipeline_library_state.cpp",
-		"state_tracker/semaphore_state.cpp",
-		"state_tracker/state_object.cpp",
-		"state_tracker/query_state.cpp",
-		"state_tracker/tensor_state.cpp",
-		"state_tracker/queue_state.cpp",
-		"state_tracker/render_pass_state.cpp",
-		"state_tracker/shader_instruction.cpp",
-		"state_tracker/shader_module.cpp",
-		"state_tracker/shader_object_state.cpp",
-		"state_tracker/shader_stage_state.cpp",
-		"state_tracker/state_tracker.cpp",
-		"state_tracker/video_session_state.cpp",
-		"state_tracker/wsi_state.cpp",
-		"stateless/sl_buffer.cpp",
-		"stateless/sl_cmd_buffer_dynamic.cpp",
-		"stateless/sl_cmd_buffer.cpp",
-		"stateless/sl_descriptor.cpp",
-		"stateless/sl_device_generated_commands.cpp",
-		"stateless/sl_device_memory.cpp",
-		"stateless/sl_external_object.cpp",
-		"stateless/sl_framebuffer.cpp",
-		"stateless/sl_image.cpp",
-		"stateless/sl_instance_device.cpp",
-		"stateless/sl_pipeline.cpp",
-		"stateless/sl_ray_tracing.cpp",
-		"stateless/sl_render_pass.cpp",
-		"stateless/sl_shader_object.cpp",
-		"stateless/sl_spirv.cpp",
-		"stateless/sl_synchronization.cpp",
-		"stateless/sl_tensor.cpp",
-		"stateless/sl_utils.cpp",
-		"stateless/sl_vuid_maps.cpp",
-		"stateless/sl_wsi.cpp",
-		"sync/sync_access_context.cpp",
-		"sync/sync_access_state.cpp",
-		"sync/sync_barrier.cpp",
-		"sync/sync_commandbuffer.cpp",
-		"sync/sync_common.cpp",
-		"sync/sync_error_messages.cpp",
-		"sync/sync_image.cpp",
-		"sync/sync_op.cpp",
-		"sync/sync_renderpass.cpp",
-		"sync/sync_reporting.cpp",
-		"sync/sync_stats.cpp",
-		"sync/sync_submit.cpp",
-		"sync/sync_validation.cpp",
-		"thread_tracker/thread_safety_validation.cpp",
-		"utils/shader_utils.cpp",
-		"layer_options.cpp"
-	};
-
-	const utilitySources = [_][]const u8{
-		"layer/vk_layer_settings.cpp",
-		"layer/vk_layer_settings_helper.cpp",
-		"layer/layer_settings_manager.cpp",
-		"layer/layer_settings_util.cpp",
-		"vulkan/vk_safe_struct_core.cpp",
-		"vulkan/vk_safe_struct_ext.cpp",
-		"vulkan/vk_safe_struct_khr.cpp",
-		"vulkan/vk_safe_struct_utils.cpp",
-		"vulkan/vk_safe_struct_vendor.cpp",
-		"vulkan/vk_safe_struct_manual.cpp"
-	};
+	const utilitySources = [_][]const u8{"layer/vk_layer_settings.cpp", "layer/vk_layer_settings_helper.cpp", "layer/layer_settings_manager.cpp", "layer/layer_settings_util.cpp", "vulkan/vk_safe_struct_core.cpp", "vulkan/vk_safe_struct_ext.cpp", "vulkan/vk_safe_struct_khr.cpp", "vulkan/vk_safe_struct_utils.cpp", "vulkan/vk_safe_struct_vendor.cpp", "vulkan/vk_safe_struct_manual.cpp"};
 
 	const gpuavSpirvSources = [_][]const u8{
 		"descriptor_indexing_oob_pass.cpp",
@@ -391,8 +183,7 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 		.windows => {
 			all_flags.append("-DVK_USE_PLATFORM_WIN32_KHR") catch unreachable;
 		},
-		.linux, .freebsd, .openbsd, .dragonfly => {
-		},
+		.linux, .freebsd, .openbsd, .dragonfly => {},
 		.ios => {
 			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
 			all_flags.append("-VK_USE_PLATFORM_IOS_MVK") catch unreachable;
@@ -401,7 +192,7 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
 			all_flags.append("-DVK_USE_PLATFORM_MACOS_MVK") catch unreachable;
 		},
-		else => {}
+		else => {},
 	}
 	all_flags.append("-DVK_ENABLE_BETA_EXTENSIONS") catch unreachable;
 
@@ -416,10 +207,22 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 	layerslib.addIncludePath(validationLayers.path("layers"));
 	layerslib.addIncludePath(validationLayers.path("layers/vulkan"));
 	layerslib.addIncludePath(validationLayers.path("layers/external"));
-	
-	layerslib.addCSourceFiles(.{ .root = utilityLibraries.path("src"), .files = &utilitySources, .flags = all_flags.items, });
-	layerslib.addCSourceFiles(.{ .root = validationLayers.path("layers"), .files = &layerSources, .flags = all_flags.items, });
-	layerslib.addCSourceFiles(.{ .root = validationLayers.path("layers/gpuav/spirv"), .files = &gpuavSpirvSources, .flags = all_flags.items, });
+
+	layerslib.addCSourceFiles(.{
+		.root = utilityLibraries.path("src"),
+		.files = &utilitySources,
+		.flags = all_flags.items,
+	});
+	layerslib.addCSourceFiles(.{
+		.root = validationLayers.path("layers"),
+		.files = &layerSources,
+		.flags = all_flags.items,
+	});
+	layerslib.addCSourceFiles(.{
+		.root = validationLayers.path("layers/gpuav/spirv"),
+		.files = &gpuavSpirvSources,
+		.flags = all_flags.items,
+	});
 	layerslib.linkLibrary(glslang.artifact("SPIRV-Tools"));
 	layerslib.linkLibrary(glslang.artifact("SPIRV-Tools-opt"));
 
@@ -451,7 +254,7 @@ pub fn addFreetypeAndHarfbuzz(b: *std.Build, c_lib: *std.Build.Step.Compile, tar
 	c_lib.addIncludePath(freetype.path("include"));
 	c_lib.installHeadersDirectory(freetype.path("include"), "", .{});
 	addPackageCSourceFiles(c_lib, freetype, &freetypeSources, flags);
-	if (target.result.os.tag == .macos) c_lib.addCSourceFile(.{
+	if(target.result.os.tag == .macos) c_lib.addCSourceFile(.{
 		.file = freetype.path("src/base/ftmac.c"),
 		.flags = &.{},
 	});
@@ -480,7 +283,7 @@ pub inline fn addGLFWSources(b: *std.Build, c_lib: *std.Build.Step.Compile, targ
 		else => blk: {
 			std.log.warn("Operating system ({}) is untested.", .{os});
 			break :blk .x11;
-		}
+		},
 	};
 	const ws_flag = switch(ws) {
 		.win32 => "-D_GLFW_WIN32",
@@ -496,20 +299,16 @@ pub inline fn addGLFWSources(b: *std.Build, c_lib: *std.Build.Step.Compile, targ
 
 	c_lib.addIncludePath(glfw.path("include"));
 	c_lib.installHeader(glfw.path("include/GLFW/glfw3.h"), "GLFW/glfw3.h");
-	const fileses : [3][]const[]const u8 = .{
-		&.{"context.c", "init.c", "input.c", "monitor.c", "platform.c", "vulkan.c", "window.c", "egl_context.c", "osmesa_context.c", "null_init.c", "null_monitor.c", "null_window.c", "null_joystick.c"},
-		switch(os) {
-			.windows => &.{"win32_module.c", "win32_time.c", "win32_thread.c" },
-			.linux => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
-			.macos => &.{"cocoa_time.c", "posix_module.c", "posix_thread.c"},
-			else => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
-		},
-		switch(ws) {
-			.win32 => &.{"win32_init.c", "win32_joystick.c", "win32_monitor.c", "win32_window.c", "wgl_context.c"},
-			.x11 => &.{"x11_init.c", "x11_monitor.c", "x11_window.c", "xkb_unicode.c", "glx_context.c", "posix_poll.c"},
-			.cocoa => &.{"cocoa_init.m", "cocoa_joystick.m", "cocoa_monitor.m", "cocoa_window.m", "nsgl_context.m"},
-		}
-	};
+	const fileses: [3][]const []const u8 = .{&.{"context.c", "init.c", "input.c", "monitor.c", "platform.c", "vulkan.c", "window.c", "egl_context.c", "osmesa_context.c", "null_init.c", "null_monitor.c", "null_window.c", "null_joystick.c"}, switch(os) {
+		.windows => &.{"win32_module.c", "win32_time.c", "win32_thread.c"},
+		.linux => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
+		.macos => &.{"cocoa_time.c", "posix_module.c", "posix_thread.c"},
+		else => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
+	}, switch(ws) {
+		.win32 => &.{"win32_init.c", "win32_joystick.c", "win32_monitor.c", "win32_window.c", "wgl_context.c"},
+		.x11 => &.{"x11_init.c", "x11_monitor.c", "x11_window.c", "xkb_unicode.c", "glx_context.c", "posix_poll.c"},
+		.cocoa => &.{"cocoa_init.m", "cocoa_joystick.m", "cocoa_monitor.m", "cocoa_window.m", "nsgl_context.m"},
+	}};
 
 	for(fileses) |files| {
 		c_lib.addCSourceFiles(.{
@@ -521,13 +320,10 @@ pub inline fn addGLFWSources(b: *std.Build, c_lib: *std.Build.Step.Compile, targ
 }
 
 pub inline fn makeCubyzLibs(b: *std.Build, step: *std.Build.Step, name: []const u8, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, flags: []const []const u8) *std.Build.Step.Compile {
-	const c_lib = b.addLibrary(.{
-		.name = name,
-		.root_module = b.createModule(.{
-			.target = target,
-			.optimize = optimize,
-		})
-	});
+	const c_lib = b.addLibrary(.{.name = name, .root_module = b.createModule(.{
+		.target = target,
+		.optimize = optimize,
+	})});
 
 	c_lib.addAfterIncludePath(b.path("include"));
 	c_lib.installHeader(b.path("include/glad/gl.h"), "glad/gl.h");
@@ -565,7 +361,7 @@ pub inline fn makeCubyzLibs(b: *std.Build, step: *std.Build.Step, name: []const 
 		.optimize = optimize,
 		.@"enable-opt" = true,
 	});
-	const options = std.Build.Step.InstallArtifact.Options {
+	const options = std.Build.Step.InstallArtifact.Options{
 		.dest_dir = .{.override = .{.custom = b.fmt("lib/{s}", .{name})}},
 	};
 	step.dependOn(&b.addInstallArtifact(glslang.artifact("glslang"), options).step);
@@ -616,7 +412,7 @@ pub fn build(b: *std.Build) !void {
 	const buildStep = b.step("build_all", "Build all targets for distribution");
 	releaseStep.dependOn(buildStep);
 
-	for (targets) |target| {
+	for(targets) |target| {
 		const t = b.resolveTargetQuery(target);
 		const name = t.result.linuxTriple(b.allocator) catch unreachable;
 		const subStep = b.step(name, b.fmt("Build only {s}", .{name}));
@@ -630,7 +426,7 @@ pub fn build(b: *std.Build) !void {
 			const layersInstall = makeVulkanLayers(b, subStep, t, .ReleaseSmall, c_flags);
 			subStep.dependOn(&layersInstall.step);
 		}
-		
+
 		buildStep.dependOn(subStep);
 	}
 

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const targets: []const std.Target.Query = &.{
 	// NB: some of these targets don't build yet in Cubyz, but are
@@ -64,76 +65,57 @@ const freetypeSources = [_][]const u8{
 	"src/winfonts/winfnt.c",
 };
 
-pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Build.ResolvedTarget, flags: []const []const u8) void {
+pub fn addVulkanApple(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Build.ResolvedTarget, flags: []const []const u8) !void {
+	std.debug.assert(target.result.os.tag.isDarwin());
+
 	const headers = b.dependency("Vulkan-Headers", .{});
 	const loader = b.dependency("Vulkan-Loader", .{});
 
-	// NOTE(blackedout): How to compile the Vulkan loader is taken from the CMakeLists of that project.
-	// This zig build is very incomplete but somehow still works on macOS
-	const normalLoaderSources = [_][]const u8{"allocation.c", "cJSON.c", "debug_utils.c", "extension_manual.c", "loader_environment.c", "gpa_helper.c", "loader.c", "log.c", "loader_json.c", "settings.c", "terminator.c", "trampoline.c", "unknown_function_handling.c", "wsi.c"};
-
-	const win32LoaderSources = [_][]const u8{
-		"loader_windows.c",
-		"dirent_on_windows.c",
+	// NOTE(blackedout): The following build is taken from the Apple paths of the Vulkan loader's CMakeLists.
+	// It is not complete as it only supports 64 bit targets, ignores the HAVE_REALPATH check and asm stuff.
+	const loaderSources = [_][]const u8{
+		"allocation.c",
+		"cJSON.c",
+		"debug_utils.c",
+		"extension_manual.c",
+		"loader_environment.c",
+		"gpa_helper.c",
+		"loader.c",
+		"log.c",
+		"loader_json.c",
+		"settings.c",
+		"terminator.c",
+		"trampoline.c",
+		"unknown_function_handling.c",
+		"wsi.c",
 	};
 
-	const linuxLoaderSources = [_][]const u8{
-		"loader_linux.c",
-	};
-
-	var all_flags = std.array_list.Managed([]const u8).init(b.allocator);
-	all_flags.appendSlice(flags) catch unreachable;
-	switch(target.result.os.tag) {
-		.windows => {
-			all_flags.append("-DVK_USE_PLATFORM_WIN32_KHR") catch unreachable;
-		},
-		.linux, .freebsd, .openbsd, .dragonfly => {},
-		.ios => {
-			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
-			all_flags.append("-VK_USE_PLATFORM_IOS_MVK") catch unreachable;
-		},
-		.macos => {
-			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
-			all_flags.append("-DVK_USE_PLATFORM_MACOS_MVK") catch unreachable;
-		},
-		else => {},
+	var allFlags: std.ArrayList([]const u8) = .{};
+	try allFlags.appendSlice(b.allocator, flags);
+	if(target.result.os.tag == .ios) {
+		try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_IOS_MVK");
+	} else if(target.result.os.tag == .macos) {
+		try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_MACOS_MVK");
 	}
-	all_flags.append("-DVK_ENABLE_BETA_EXTENSIONS") catch unreachable;
-
-	// NOTE(blackedout): Should really be if UNIX
-	if(target.result.os.tag == .linux or target.result.os.tag == .macos) {
-		all_flags.append("-DFALLBACK_CONFIG_DIRS=\"/etc/xdg\"") catch unreachable;
-		all_flags.append("-DFALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\"") catch unreachable;
-		all_flags.append("-DSYSCONFDIR=\"/etc\"") catch unreachable;
-	}
+	try allFlags.appendSlice(b.allocator, &[_][]const u8{
+		"-DVK_USE_PLATFORM_METAL_EXT",
+		"-DVK_ENABLE_BETA_EXTENSIONS",
+		"-DFALLBACK_CONFIG_DIRS=\"/etc/xdg\"",
+		"-DFALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\"",
+		"-DSYSCONFDIR=\"/etc\"",
+	});
+	try allFlags.append(b.allocator, "-fno-strict-aliasing");
 
 	c_lib.addIncludePath(headers.path("include"));
 	c_lib.addIncludePath(loader.path("loader"));
+
 	c_lib.addIncludePath(loader.path("loader/generated"));
 	c_lib.installHeadersDirectory(headers.path("include"), "", .{});
 	c_lib.addCSourceFiles(.{
 		.root = loader.path("loader"),
-		.files = &normalLoaderSources,
-		.flags = all_flags.items,
+		.files = &loaderSources,
+		.flags = allFlags.items,
 	});
-	switch(target.result.os.tag) {
-		.windows => {
-			c_lib.addCSourceFiles(.{
-				.root = loader.path("loader"),
-				.files = &win32LoaderSources,
-				.flags = all_flags.items,
-			});
-		},
-		.linux, .freebsd, .openbsd, .dragonfly => {
-			c_lib.addCSourceFiles(.{
-				.root = loader.path("loader"),
-				.files = &linuxLoaderSources,
-				.flags = all_flags.items,
-			});
-		},
-		.macos => {},
-		else => {},
-	}
 
 	// NOTE(blackedout): Add the MoltenVK binary and JSON manifest file
 	if(target.result.os.tag == .macos) {
@@ -145,7 +127,7 @@ pub fn addVulkan(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Buil
 	}
 }
 
-pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, flags: []const []const u8) *std.Build.Step.InstallArtifact {
+pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, flags: []const []const u8) !*std.Build.Step.InstallArtifact {
 	const layerslib = b.addLibrary(.{.name = "VkLayer_khronos_validation", .root_module = b.createModule(.{
 		.target = target,
 		.optimize = optimize,
@@ -157,9 +139,207 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 
 	// NOTE(blackedout): How to compile the Vulkan validation layers is taken from the CMakeLists of that project.
 	// This zig build is very incomplete but somehow still works on macOS
-	const layerSources = [_][]const u8{"error_message/logging.cpp", "error_message/error_location.cpp", "vulkan/generated/error_location_helper.cpp", "vulkan/generated/feature_requirements_helper.cpp", "vulkan/generated/pnext_chain_extraction.cpp", "vulkan/generated/vk_function_pointers.cpp", "vulkan/generated/vk_dispatch_table_helper.cpp", "vulkan/generated/vk_object_types.cpp", "vulkan/generated/vk_extension_helper.cpp", "utils/convert_utils.cpp", "utils/dispatch_utils.cpp", "utils/file_system_utils.cpp", "utils/hash_util.cpp", "utils/image_utils.cpp", "utils/image_layout_utils.cpp", "utils/vk_layer_extension_utils.cpp", "utils/keyboard.cpp", "utils/ray_tracing_utils.cpp", "utils/sync_utils.cpp", "utils/text_utils.cpp", "utils/vk_struct_compare.cpp", "vk_layer_config.cpp", "best_practices/bp_buffer.cpp", "best_practices/bp_cmd_buffer.cpp", "best_practices/bp_cmd_buffer_nv.cpp", "best_practices/bp_copy_blit_resolve.cpp", "best_practices/bp_descriptor.cpp", "best_practices/bp_device_memory.cpp", "best_practices/bp_drawdispatch.cpp", "best_practices/bp_framebuffer.cpp", "best_practices/bp_image.cpp", "best_practices/bp_instance_device.cpp", "best_practices/bp_pipeline.cpp", "best_practices/bp_ray_tracing.cpp", "best_practices/bp_render_pass.cpp", "best_practices/bp_state_tracker.cpp", "best_practices/bp_state.cpp", "best_practices/bp_synchronization.cpp", "best_practices/bp_utils.cpp", "best_practices/bp_video.cpp", "best_practices/bp_wsi.cpp", "chassis/chassis_manual.cpp", "chassis/dispatch_object_manual.cpp", "containers/subresource_adapter.cpp", "core_checks/cc_android.cpp", "core_checks/cc_buffer.cpp", "core_checks/cc_cmd_buffer_dynamic.cpp", "core_checks/cc_cmd_buffer.cpp", "core_checks/cc_copy_blit_resolve.cpp", "core_checks/cc_data_graph.cpp", "core_checks/cc_descriptor.cpp", "core_checks/cc_device.cpp", "core_checks/cc_device_memory.cpp", "core_checks/cc_device_generated_commands.cpp", "core_checks/cc_drawdispatch.cpp", "core_checks/cc_external_object.cpp", "core_checks/cc_image.cpp", "core_checks/cc_image_layout.cpp", "core_checks/cc_pipeline_compute.cpp", "core_checks/cc_pipeline_graphics.cpp", "core_checks/cc_pipeline_ray_tracing.cpp", "core_checks/cc_pipeline.cpp", "core_checks/cc_query.cpp", "core_checks/cc_queue.cpp", "core_checks/cc_ray_tracing.cpp", "core_checks/cc_render_pass.cpp", "core_checks/cc_spirv.cpp", "core_checks/cc_shader_interface.cpp", "core_checks/cc_shader_object.cpp", "core_checks/cc_state_tracker.cpp", "core_checks/cc_submit.cpp", "core_checks/cc_sync_vuid_maps.cpp", "core_checks/cc_synchronization.cpp", "core_checks/cc_tensor.cpp", "core_checks/cc_video.cpp", "core_checks/cc_vuid_maps.cpp", "core_checks/cc_wsi.cpp", "core_checks/cc_ycbcr.cpp", "drawdispatch/descriptor_validator.cpp", "drawdispatch/drawdispatch_vuids.cpp", "error_message/spirv_logging.cpp", "external/vma/vma.cpp", "vulkan/generated/best_practices.cpp", "vulkan/generated/chassis.cpp", "vulkan/generated/valid_enum_values.cpp", "vulkan/generated/valid_flag_values.cpp", "vulkan/generated/command_validation.cpp", "vulkan/generated/deprecation.cpp", "vulkan/generated/device_features.cpp", "vulkan/generated/dynamic_state_helper.cpp", "vulkan/generated/feature_not_present.cpp", "vulkan/generated/dispatch_vector.cpp", "vulkan/generated/dispatch_object.cpp", "vulkan/generated/validation_object.cpp", "vulkan/generated/object_tracker.cpp", "vulkan/generated/spirv_grammar_helper.cpp", "vulkan/generated/spirv_validation_helper.cpp", "vulkan/generated/stateless_validation_helper.cpp", "vulkan/generated/sync_validation_types.cpp", "vulkan/generated/thread_safety.cpp", "vulkan/generated/gpuav_offline_spirv.cpp", "gpuav/core/gpuav_features.cpp", "gpuav/core/gpuav_record.cpp", "gpuav/core/gpuav_setup.cpp", "gpuav/core/gpuav_settings.cpp", "gpuav/core/gpuav_validation_pipeline.cpp", "gpuav/validation_cmd/gpuav_validation_cmd_common.cpp", "gpuav/validation_cmd/gpuav_draw.cpp", "gpuav/validation_cmd/gpuav_dispatch.cpp", "gpuav/validation_cmd/gpuav_trace_rays.cpp", "gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp", "gpuav/descriptor_validation/gpuav_descriptor_validation.cpp", "gpuav/descriptor_validation/gpuav_descriptor_set.cpp", "gpuav/debug_printf/debug_printf.cpp", "gpuav/error_message/gpuav_vuids.cpp", "gpuav/instrumentation/gpuav_shader_instrumentor.cpp", "gpuav/instrumentation/gpuav_instrumentation.cpp", "gpuav/instrumentation/buffer_device_address.cpp", "gpuav/instrumentation/descriptor_checks.cpp", "gpuav/instrumentation/post_process_descriptor_indexing.cpp", "gpuav/resources/gpuav_state_trackers.cpp", "gpuav/resources/gpuav_vulkan_objects.cpp", "object_tracker/object_tracker_utils.cpp", "state_tracker/buffer_state.cpp", "state_tracker/cmd_buffer_state.cpp", "state_tracker/data_graph_pipeline_session_state.cpp", "state_tracker/descriptor_sets.cpp", "state_tracker/device_generated_commands_state.cpp", "state_tracker/device_memory_state.cpp", "state_tracker/device_state.cpp", "state_tracker/fence_state.cpp", "state_tracker/image_layout_map.cpp", "state_tracker/image_state.cpp", "state_tracker/last_bound_state.cpp", "state_tracker/pipeline_layout_state.cpp", "state_tracker/pipeline_state.cpp", "state_tracker/pipeline_library_state.cpp", "state_tracker/semaphore_state.cpp", "state_tracker/state_object.cpp", "state_tracker/query_state.cpp", "state_tracker/tensor_state.cpp", "state_tracker/queue_state.cpp", "state_tracker/render_pass_state.cpp", "state_tracker/shader_instruction.cpp", "state_tracker/shader_module.cpp", "state_tracker/shader_object_state.cpp", "state_tracker/shader_stage_state.cpp", "state_tracker/state_tracker.cpp", "state_tracker/video_session_state.cpp", "state_tracker/wsi_state.cpp", "stateless/sl_buffer.cpp", "stateless/sl_cmd_buffer_dynamic.cpp", "stateless/sl_cmd_buffer.cpp", "stateless/sl_descriptor.cpp", "stateless/sl_device_generated_commands.cpp", "stateless/sl_device_memory.cpp", "stateless/sl_external_object.cpp", "stateless/sl_framebuffer.cpp", "stateless/sl_image.cpp", "stateless/sl_instance_device.cpp", "stateless/sl_pipeline.cpp", "stateless/sl_ray_tracing.cpp", "stateless/sl_render_pass.cpp", "stateless/sl_shader_object.cpp", "stateless/sl_spirv.cpp", "stateless/sl_synchronization.cpp", "stateless/sl_tensor.cpp", "stateless/sl_utils.cpp", "stateless/sl_vuid_maps.cpp", "stateless/sl_wsi.cpp", "sync/sync_access_context.cpp", "sync/sync_access_state.cpp", "sync/sync_barrier.cpp", "sync/sync_commandbuffer.cpp", "sync/sync_common.cpp", "sync/sync_error_messages.cpp", "sync/sync_image.cpp", "sync/sync_op.cpp", "sync/sync_renderpass.cpp", "sync/sync_reporting.cpp", "sync/sync_stats.cpp", "sync/sync_submit.cpp", "sync/sync_validation.cpp", "thread_tracker/thread_safety_validation.cpp", "utils/shader_utils.cpp", "layer_options.cpp"};
+	const layerSources = [_][]const u8{
+		"error_message/logging.cpp",
+		"error_message/error_location.cpp",
+		"vulkan/generated/error_location_helper.cpp",
+		"vulkan/generated/feature_requirements_helper.cpp",
+		"vulkan/generated/pnext_chain_extraction.cpp",
+		"vulkan/generated/vk_function_pointers.cpp",
+		"vulkan/generated/vk_dispatch_table_helper.cpp",
+		"vulkan/generated/vk_object_types.cpp",
+		"vulkan/generated/vk_extension_helper.cpp",
+		"utils/convert_utils.cpp",
+		"utils/dispatch_utils.cpp",
+		"utils/file_system_utils.cpp",
+		"utils/hash_util.cpp",
+		"utils/image_utils.cpp",
+		"utils/image_layout_utils.cpp",
+		"utils/vk_layer_extension_utils.cpp",
+		"utils/keyboard.cpp",
+		"utils/ray_tracing_utils.cpp",
+		"utils/sync_utils.cpp",
+		"utils/text_utils.cpp",
+		"utils/vk_struct_compare.cpp",
+		"vk_layer_config.cpp",
+		"best_practices/bp_buffer.cpp",
+		"best_practices/bp_cmd_buffer.cpp",
+		"best_practices/bp_cmd_buffer_nv.cpp",
+		"best_practices/bp_copy_blit_resolve.cpp",
+		"best_practices/bp_descriptor.cpp",
+		"best_practices/bp_device_memory.cpp",
+		"best_practices/bp_drawdispatch.cpp",
+		"best_practices/bp_framebuffer.cpp",
+		"best_practices/bp_image.cpp",
+		"best_practices/bp_instance_device.cpp",
+		"best_practices/bp_pipeline.cpp",
+		"best_practices/bp_ray_tracing.cpp",
+		"best_practices/bp_render_pass.cpp",
+		"best_practices/bp_state_tracker.cpp",
+		"best_practices/bp_state.cpp",
+		"best_practices/bp_synchronization.cpp",
+		"best_practices/bp_utils.cpp",
+		"best_practices/bp_video.cpp",
+		"best_practices/bp_wsi.cpp",
+		"chassis/chassis_manual.cpp",
+		"chassis/dispatch_object_manual.cpp",
+		"containers/subresource_adapter.cpp",
+		"core_checks/cc_android.cpp",
+		"core_checks/cc_buffer.cpp",
+		"core_checks/cc_cmd_buffer_dynamic.cpp",
+		"core_checks/cc_cmd_buffer.cpp",
+		"core_checks/cc_copy_blit_resolve.cpp",
+		"core_checks/cc_data_graph.cpp",
+		"core_checks/cc_descriptor.cpp",
+		"core_checks/cc_device.cpp",
+		"core_checks/cc_device_memory.cpp",
+		"core_checks/cc_device_generated_commands.cpp",
+		"core_checks/cc_drawdispatch.cpp",
+		"core_checks/cc_external_object.cpp",
+		"core_checks/cc_image.cpp",
+		"core_checks/cc_image_layout.cpp",
+		"core_checks/cc_pipeline_compute.cpp",
+		"core_checks/cc_pipeline_graphics.cpp",
+		"core_checks/cc_pipeline_ray_tracing.cpp",
+		"core_checks/cc_pipeline.cpp",
+		"core_checks/cc_query.cpp",
+		"core_checks/cc_queue.cpp",
+		"core_checks/cc_ray_tracing.cpp",
+		"core_checks/cc_render_pass.cpp",
+		"core_checks/cc_spirv.cpp",
+		"core_checks/cc_shader_interface.cpp",
+		"core_checks/cc_shader_object.cpp",
+		"core_checks/cc_state_tracker.cpp",
+		"core_checks/cc_submit.cpp",
+		"core_checks/cc_sync_vuid_maps.cpp",
+		"core_checks/cc_synchronization.cpp",
+		"core_checks/cc_tensor.cpp",
+		"core_checks/cc_video.cpp",
+		"core_checks/cc_vuid_maps.cpp",
+		"core_checks/cc_wsi.cpp",
+		"core_checks/cc_ycbcr.cpp",
+		"drawdispatch/descriptor_validator.cpp",
+		"drawdispatch/drawdispatch_vuids.cpp",
+		"error_message/spirv_logging.cpp",
+		"external/vma/vma.cpp",
+		"vulkan/generated/best_practices.cpp",
+		"vulkan/generated/chassis.cpp",
+		"vulkan/generated/valid_enum_values.cpp",
+		"vulkan/generated/valid_flag_values.cpp",
+		"vulkan/generated/command_validation.cpp",
+		"vulkan/generated/deprecation.cpp",
+		"vulkan/generated/device_features.cpp",
+		"vulkan/generated/dynamic_state_helper.cpp",
+		"vulkan/generated/feature_not_present.cpp",
+		"vulkan/generated/dispatch_vector.cpp",
+		"vulkan/generated/dispatch_object.cpp",
+		"vulkan/generated/validation_object.cpp",
+		"vulkan/generated/object_tracker.cpp",
+		"vulkan/generated/spirv_grammar_helper.cpp",
+		"vulkan/generated/spirv_validation_helper.cpp",
+		"vulkan/generated/stateless_validation_helper.cpp",
+		"vulkan/generated/sync_validation_types.cpp",
+		"vulkan/generated/thread_safety.cpp",
+		"vulkan/generated/gpuav_offline_spirv.cpp",
+		"gpuav/core/gpuav_features.cpp",
+		"gpuav/core/gpuav_record.cpp",
+		"gpuav/core/gpuav_setup.cpp",
+		"gpuav/core/gpuav_settings.cpp",
+		"gpuav/core/gpuav_validation_pipeline.cpp",
+		"gpuav/validation_cmd/gpuav_validation_cmd_common.cpp",
+		"gpuav/validation_cmd/gpuav_draw.cpp",
+		"gpuav/validation_cmd/gpuav_dispatch.cpp",
+		"gpuav/validation_cmd/gpuav_trace_rays.cpp",
+		"gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp",
+		"gpuav/descriptor_validation/gpuav_descriptor_validation.cpp",
+		"gpuav/descriptor_validation/gpuav_descriptor_set.cpp",
+		"gpuav/debug_printf/debug_printf.cpp",
+		"gpuav/error_message/gpuav_vuids.cpp",
+		"gpuav/instrumentation/gpuav_shader_instrumentor.cpp",
+		"gpuav/instrumentation/gpuav_instrumentation.cpp",
+		"gpuav/instrumentation/buffer_device_address.cpp",
+		"gpuav/instrumentation/descriptor_checks.cpp",
+		"gpuav/instrumentation/post_process_descriptor_indexing.cpp",
+		"gpuav/resources/gpuav_state_trackers.cpp",
+		"gpuav/resources/gpuav_vulkan_objects.cpp",
+		"object_tracker/object_tracker_utils.cpp",
+		"state_tracker/buffer_state.cpp",
+		"state_tracker/cmd_buffer_state.cpp",
+		"state_tracker/data_graph_pipeline_session_state.cpp",
+		"state_tracker/descriptor_sets.cpp",
+		"state_tracker/device_generated_commands_state.cpp",
+		"state_tracker/device_memory_state.cpp",
+		"state_tracker/device_state.cpp",
+		"state_tracker/fence_state.cpp",
+		"state_tracker/image_layout_map.cpp",
+		"state_tracker/image_state.cpp",
+		"state_tracker/last_bound_state.cpp",
+		"state_tracker/pipeline_layout_state.cpp",
+		"state_tracker/pipeline_state.cpp",
+		"state_tracker/pipeline_library_state.cpp",
+		"state_tracker/semaphore_state.cpp",
+		"state_tracker/state_object.cpp",
+		"state_tracker/query_state.cpp",
+		"state_tracker/tensor_state.cpp",
+		"state_tracker/queue_state.cpp",
+		"state_tracker/render_pass_state.cpp",
+		"state_tracker/shader_instruction.cpp",
+		"state_tracker/shader_module.cpp",
+		"state_tracker/shader_object_state.cpp",
+		"state_tracker/shader_stage_state.cpp",
+		"state_tracker/state_tracker.cpp",
+		"state_tracker/video_session_state.cpp",
+		"state_tracker/wsi_state.cpp",
+		"stateless/sl_buffer.cpp",
+		"stateless/sl_cmd_buffer_dynamic.cpp",
+		"stateless/sl_cmd_buffer.cpp",
+		"stateless/sl_descriptor.cpp",
+		"stateless/sl_device_generated_commands.cpp",
+		"stateless/sl_device_memory.cpp",
+		"stateless/sl_external_object.cpp",
+		"stateless/sl_framebuffer.cpp",
+		"stateless/sl_image.cpp",
+		"stateless/sl_instance_device.cpp",
+		"stateless/sl_pipeline.cpp",
+		"stateless/sl_ray_tracing.cpp",
+		"stateless/sl_render_pass.cpp",
+		"stateless/sl_shader_object.cpp",
+		"stateless/sl_spirv.cpp",
+		"stateless/sl_synchronization.cpp",
+		"stateless/sl_tensor.cpp",
+		"stateless/sl_utils.cpp",
+		"stateless/sl_vuid_maps.cpp",
+		"stateless/sl_wsi.cpp",
+		"sync/sync_access_context.cpp",
+		"sync/sync_access_state.cpp",
+		"sync/sync_barrier.cpp",
+		"sync/sync_commandbuffer.cpp",
+		"sync/sync_common.cpp",
+		"sync/sync_error_messages.cpp",
+		"sync/sync_image.cpp",
+		"sync/sync_op.cpp",
+		"sync/sync_renderpass.cpp",
+		"sync/sync_reporting.cpp",
+		"sync/sync_stats.cpp",
+		"sync/sync_submit.cpp",
+		"sync/sync_validation.cpp",
+		"thread_tracker/thread_safety_validation.cpp",
+		"utils/shader_utils.cpp",
+		"layer_options.cpp",
+	};
 
-	const utilitySources = [_][]const u8{"layer/vk_layer_settings.cpp", "layer/vk_layer_settings_helper.cpp", "layer/layer_settings_manager.cpp", "layer/layer_settings_util.cpp", "vulkan/vk_safe_struct_core.cpp", "vulkan/vk_safe_struct_ext.cpp", "vulkan/vk_safe_struct_khr.cpp", "vulkan/vk_safe_struct_utils.cpp", "vulkan/vk_safe_struct_vendor.cpp", "vulkan/vk_safe_struct_manual.cpp"};
+	const utilitySources = [_][]const u8{
+		"layer/vk_layer_settings.cpp",
+		"layer/vk_layer_settings_helper.cpp",
+		"layer/layer_settings_manager.cpp",
+		"layer/layer_settings_util.cpp",
+		"vulkan/vk_safe_struct_core.cpp",
+		"vulkan/vk_safe_struct_ext.cpp",
+		"vulkan/vk_safe_struct_khr.cpp",
+		"vulkan/vk_safe_struct_utils.cpp",
+		"vulkan/vk_safe_struct_vendor.cpp",
+		"vulkan/vk_safe_struct_manual.cpp",
+	};
 
 	const gpuavSpirvSources = [_][]const u8{
 		"descriptor_indexing_oob_pass.cpp",
@@ -177,26 +357,26 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 		"pass.cpp",
 	};
 
-	var all_flags = std.array_list.Managed([]const u8).init(b.allocator);
-	all_flags.appendSlice(flags) catch unreachable;
+	var allFlags: std.ArrayList([]const u8) = .{};
+	try allFlags.appendSlice(b.allocator, flags);
 	switch(target.result.os.tag) {
 		.windows => {
-			all_flags.append("-DVK_USE_PLATFORM_WIN32_KHR") catch unreachable;
+			try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_WIN32_KHR");
 		},
 		.linux, .freebsd, .openbsd, .dragonfly => {},
 		.ios => {
-			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
-			all_flags.append("-VK_USE_PLATFORM_IOS_MVK") catch unreachable;
+			try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_METAL_EXT");
+			try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_IOS_MVK");
 		},
 		.macos => {
-			all_flags.append("-DVK_USE_PLATFORM_METAL_EXT") catch unreachable;
-			all_flags.append("-DVK_USE_PLATFORM_MACOS_MVK") catch unreachable;
+			try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_METAL_EXT");
+			try allFlags.append(b.allocator, "-DVK_USE_PLATFORM_MACOS_MVK");
 		},
 		else => {},
 	}
-	all_flags.append("-DVK_ENABLE_BETA_EXTENSIONS") catch unreachable;
+	try allFlags.append(b.allocator, "-DVK_ENABLE_BETA_EXTENSIONS");
 
-	const glslang = b.dependency("glslang", .{});
+	const glslang = b.dependency("glslang", .{.target = target, .optimize = optimize});
 	const spirvHeaders = b.dependency("SPIRV-Headers", .{});
 	const spirvTools = glslang.builder.dependency("SPIRV-Tools", .{});
 
@@ -211,17 +391,17 @@ pub fn makeVulkanLayers(b: *std.Build, parentStep: *std.Build.Step, target: std.
 	layerslib.addCSourceFiles(.{
 		.root = utilityLibraries.path("src"),
 		.files = &utilitySources,
-		.flags = all_flags.items,
+		.flags = allFlags.items,
 	});
 	layerslib.addCSourceFiles(.{
 		.root = validationLayers.path("layers"),
 		.files = &layerSources,
-		.flags = all_flags.items,
+		.flags = allFlags.items,
 	});
 	layerslib.addCSourceFiles(.{
 		.root = validationLayers.path("layers/gpuav/spirv"),
 		.files = &gpuavSpirvSources,
-		.flags = all_flags.items,
+		.flags = allFlags.items,
 	});
 	layerslib.linkLibrary(glslang.artifact("SPIRV-Tools"));
 	layerslib.linkLibrary(glslang.artifact("SPIRV-Tools-opt"));
@@ -266,7 +446,7 @@ pub fn addFreetypeAndHarfbuzz(b: *std.Build, c_lib: *std.Build.Step.Compile, tar
 	c_lib.linkLibCpp();
 }
 
-pub inline fn addGLFWSources(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Build.ResolvedTarget, flags: []const []const u8) void {
+pub inline fn addGLFWSources(b: *std.Build, c_lib: *std.Build.Step.Compile, target: std.Build.ResolvedTarget, flags: []const []const u8) !void {
 	const glfw = b.dependency("glfw", .{});
 	const root = glfw.path("src");
 	const os = target.result.os.tag;
@@ -285,45 +465,58 @@ pub inline fn addGLFWSources(b: *std.Build, c_lib: *std.Build.Step.Compile, targ
 			break :blk .x11;
 		},
 	};
-	const ws_flag = switch(ws) {
+	const wsFlag = switch(ws) {
 		.win32 => "-D_GLFW_WIN32",
 		.x11 => "-D_GLFW_X11",
 		.cocoa => "-D_GLFW_COCOA",
 	};
-	var all_flags = std.array_list.Managed([]const u8).init(b.allocator);
-	all_flags.appendSlice(flags) catch unreachable;
-	all_flags.append(ws_flag) catch unreachable;
+	var allFlags = try std.ArrayList([]const u8).initCapacity(b.allocator, 0);
+	try allFlags.appendSlice(b.allocator, flags);
+	try allFlags.append(b.allocator, wsFlag);
 	if(os == .linux) {
-		all_flags.append("-D_GNU_SOURCE") catch unreachable;
+		try allFlags.append(b.allocator, "-D_GNU_SOURCE");
 	}
 
 	c_lib.addIncludePath(glfw.path("include"));
 	c_lib.installHeader(glfw.path("include/GLFW/glfw3.h"), "GLFW/glfw3.h");
-	const fileses: [3][]const []const u8 = .{&.{"context.c", "init.c", "input.c", "monitor.c", "platform.c", "vulkan.c", "window.c", "egl_context.c", "osmesa_context.c", "null_init.c", "null_monitor.c", "null_window.c", "null_joystick.c"}, switch(os) {
-		.windows => &.{"win32_module.c", "win32_time.c", "win32_thread.c"},
-		.linux => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
-		.macos => &.{"cocoa_time.c", "posix_module.c", "posix_thread.c"},
-		else => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
-	}, switch(ws) {
-		.win32 => &.{"win32_init.c", "win32_joystick.c", "win32_monitor.c", "win32_window.c", "wgl_context.c"},
-		.x11 => &.{"x11_init.c", "x11_monitor.c", "x11_window.c", "xkb_unicode.c", "glx_context.c", "posix_poll.c"},
-		.cocoa => &.{"cocoa_init.m", "cocoa_joystick.m", "cocoa_monitor.m", "cocoa_window.m", "nsgl_context.m"},
-	}};
+	const fileses: [3][]const []const u8 = .{
+		&.{"context.c", "init.c", "input.c", "monitor.c", "platform.c", "vulkan.c", "window.c", "egl_context.c", "osmesa_context.c", "null_init.c", "null_monitor.c", "null_window.c", "null_joystick.c"},
+		switch(os) {
+			.windows => &.{"win32_module.c", "win32_time.c", "win32_thread.c"},
+			.linux => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
+			.macos => &.{"cocoa_time.c", "posix_module.c", "posix_thread.c"},
+			else => &.{"posix_module.c", "posix_time.c", "posix_thread.c", "linux_joystick.c"},
+		},
+		switch(ws) {
+			.win32 => &.{"win32_init.c", "win32_joystick.c", "win32_monitor.c", "win32_window.c", "wgl_context.c"},
+			.x11 => &.{"x11_init.c", "x11_monitor.c", "x11_window.c", "xkb_unicode.c", "glx_context.c", "posix_poll.c"},
+			.cocoa => &.{"cocoa_init.m", "cocoa_joystick.m", "cocoa_monitor.m", "cocoa_window.m", "nsgl_context.m"},
+		},
+	};
 
 	for(fileses) |files| {
 		c_lib.addCSourceFiles(.{
 			.root = root,
 			.files = files,
-			.flags = all_flags.items,
+			.flags = allFlags.items,
 		});
 	}
 }
 
-pub inline fn makeCubyzLibs(b: *std.Build, step: *std.Build.Step, name: []const u8, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, flags: []const []const u8) *std.Build.Step.Compile {
+pub inline fn makeCubyzLibs(b: *std.Build, step: *std.Build.Step, name: []const u8, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, flags: []const []const u8) !*std.Build.Step.Compile {
 	const c_lib = b.addLibrary(.{.name = name, .root_module = b.createModule(.{
 		.target = target,
 		.optimize = optimize,
 	})});
+
+	// NOTE(blackedout): To cross compile on macOS to macOS, the SDK has to be set correctly
+	if(builtin.os.tag == .macos and target.result.os.tag == .macos) {
+		const sdkPathNewline = b.run(&.{"xcrun", "-sdk", "macosx", "--show-sdk-path"});
+		const sdkPath = sdkPathNewline[0..(sdkPathNewline.len - 1)];
+		c_lib.root_module.addSystemFrameworkPath(.{.cwd_relative = b.fmt("{s}/System/Library/Frameworks", .{sdkPath})});
+		c_lib.root_module.addSystemIncludePath(.{.cwd_relative = b.fmt("{s}/usr/include", .{sdkPath})});
+		c_lib.root_module.addLibraryPath(.{.cwd_relative = b.fmt("{s}/usr/lib", .{sdkPath})});
+	}
 
 	c_lib.addAfterIncludePath(b.path("include"));
 	c_lib.installHeader(b.path("include/glad/gl.h"), "glad/gl.h");
@@ -344,10 +537,10 @@ pub inline fn makeCubyzLibs(b: *std.Build, step: *std.Build.Step, name: []const 
 
 	// NOTE(blackedout): `addVulkan` is only tested/needed on macOS so far
 	if(target.result.os.tag == .macos) {
-		addVulkan(b, c_lib, target, flags);
+		try addVulkanApple(b, c_lib, target, flags);
 	}
 
-	addGLFWSources(b, c_lib, target, flags);
+	try addGLFWSources(b, c_lib, target, flags);
 	c_lib.addCSourceFile(.{.file = b.path("lib/gl.c"), .flags = flags});
 
 	// NOTE(blackedout): See the above glad comment
@@ -417,13 +610,13 @@ pub fn build(b: *std.Build) !void {
 		const name = t.result.linuxTriple(b.allocator) catch unreachable;
 		const subStep = b.step(name, b.fmt("Build only {s}", .{name}));
 		const deps = b.fmt("cubyz_deps_{s}", .{name});
-		const c_lib = makeCubyzLibs(b, subStep, deps, t, .ReleaseSmall, c_flags);
+		const c_lib = try makeCubyzLibs(b, subStep, deps, t, .ReleaseSmall, c_flags);
 		const install = b.addInstallArtifact(c_lib, .{});
 
 		subStep.dependOn(&install.step);
 
 		if(t.result.os.tag == .macos) {
-			const layersInstall = makeVulkanLayers(b, subStep, t, .ReleaseSmall, c_flags);
+			const layersInstall = try makeVulkanLayers(b, subStep, t, .ReleaseSmall, c_flags);
 			subStep.dependOn(&layersInstall.step);
 		}
 
@@ -432,13 +625,13 @@ pub fn build(b: *std.Build) !void {
 
 	{
 		const name = preferredTarget.result.linuxTriple(b.allocator) catch unreachable;
-		const c_lib = makeCubyzLibs(b, nativeStep, b.fmt("cubyz_deps_{s}", .{name}), preferredTarget, preferredOptimize, c_flags);
+		const c_lib = try makeCubyzLibs(b, nativeStep, b.fmt("cubyz_deps_{s}", .{name}), preferredTarget, preferredOptimize, c_flags);
 		const install = b.addInstallArtifact(c_lib, .{});
 
 		nativeStep.dependOn(&install.step);
 
 		if(preferredTarget.result.os.tag == .macos) {
-			const layersInstall = makeVulkanLayers(b, nativeStep, preferredTarget, preferredOptimize, c_flags);
+			const layersInstall = try makeVulkanLayers(b, nativeStep, preferredTarget, preferredOptimize, c_flags);
 			nativeStep.dependOn(&layersInstall.step);
 		}
 	}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,24 +1,36 @@
 .{
-	.name = .cubyz_libs,
-	.fingerprint = 0x309b84abf3e7800f,
-	.version = "0.0.0",
-	.paths = .{""},
-	.dependencies = .{
-		.glfw = .{
-			.url = "https://github.com/glfw/glfw/archive/refs/tags/3.4.tar.gz",
-			.hash = "N-V-__8AAL40TADEbrysYHBl-UIZO4KiG4chP8pLDVDINGH4",
-		},
-		.harfbuzz = .{
-			.url = "https://github.com/harfbuzz/harfbuzz/archive/refs/tags/8.2.2.tar.gz",
-			.hash = "N-V-__8AAMnvlQXSfQ493UdwXL4VBQdgWMtBZJM2016lE2ns",
-		},
-		.freetype = .{
-			.url = "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
-			.hash = "N-V-__8AAKLKpwC4H27Ps_0iL3bPkQb-z6ZVSrB-x_3EEkub",
-		},
-		.glslang = .{
-			.url = "https://github.com/Games-by-Mason/glslang-zig/archive/4d2877072dc0ebb97698e6620a59e55ef3f367ce.tar.gz",
-			.hash = "glslang-1.4.309-eMn68Pu-CQBK98WlBPbet0hMUVM2hNWdVP4mKn1hNsD-",
-		},
-	},
+    .name = .cubyz_libs,
+    .fingerprint = 0x309b84abf3e7800f,
+    .version = "0.0.0",
+    .paths = .{""},
+    .dependencies = .{
+        .glfw = .{
+            .url = "https://github.com/glfw/glfw/archive/refs/tags/3.4.tar.gz",
+            .hash = "N-V-__8AAL40TADEbrysYHBl-UIZO4KiG4chP8pLDVDINGH4",
+        },
+        .harfbuzz = .{
+            .url = "https://github.com/harfbuzz/harfbuzz/archive/refs/tags/8.2.2.tar.gz",
+            .hash = "N-V-__8AAMnvlQXSfQ493UdwXL4VBQdgWMtBZJM2016lE2ns",
+        },
+        .freetype = .{
+            .url = "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
+            .hash = "N-V-__8AAKLKpwC4H27Ps_0iL3bPkQb-z6ZVSrB-x_3EEkub",
+        },
+        .glslang = .{
+            .url = "https://github.com/Games-by-Mason/glslang-zig/archive/cf74b30857e349c819c1c34ec717d4c9fc0eec5c.tar.gz",
+            .hash = "glslang-1.4.309-eMn68KLGCQDAuHVUzugaYOOEhbkyHmN526R7mHIq9YUs",
+        },
+        .vulkanheaders = .{
+            .url = "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.330.tar.gz",
+            .hash = "N-V-__8AAFXYAQKsK51AAGXB9HziPDFjS_DVUq6_QHVxHrBM",
+        },
+        .vulkanloader = .{
+            .url = "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.4.330.tar.gz",
+            .hash = "N-V-__8AAGYqgADJ4CSWkkwZd12lq-o6Y9ByBpscPmS_tpH4",
+        },
+        .moltenv_macos = .{
+            .url = "https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.0/MoltenVK-macos.tar",
+            .hash = "N-V-__8AAO62gwMuCOpZesC2YsUnsRFbbzsCigpvKBUl8QwB",
+        },
+    },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,48 +1,48 @@
 .{
-    .name = .cubyz_libs,
-    .fingerprint = 0x309b84abf3e7800f,
-    .version = "0.0.0",
-    .paths = .{""},
-    .dependencies = .{
-        .glfw = .{
-            .url = "https://github.com/glfw/glfw/archive/refs/tags/3.4.tar.gz",
-            .hash = "N-V-__8AAL40TADEbrysYHBl-UIZO4KiG4chP8pLDVDINGH4",
-        },
-        .harfbuzz = .{
-            .url = "https://github.com/harfbuzz/harfbuzz/archive/refs/tags/8.2.2.tar.gz",
-            .hash = "N-V-__8AAMnvlQXSfQ493UdwXL4VBQdgWMtBZJM2016lE2ns",
-        },
-        .freetype = .{
-            .url = "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
-            .hash = "N-V-__8AAKLKpwC4H27Ps_0iL3bPkQb-z6ZVSrB-x_3EEkub",
-        },
-        .glslang = .{
-            .url = "https://github.com/Games-by-Mason/glslang-zig/archive/cf74b30857e349c819c1c34ec717d4c9fc0eec5c.tar.gz",
-            .hash = "glslang-1.4.309-eMn68KLGCQDAuHVUzugaYOOEhbkyHmN526R7mHIq9YUs",
-        },
-        .@"Vulkan-Headers" = .{
-            .url = "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.330.tar.gz",
-            .hash = "N-V-__8AAFXYAQKsK51AAGXB9HziPDFjS_DVUq6_QHVxHrBM",
-        },
-        .@"Vulkan-Loader" = .{
-            .url = "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.4.330.tar.gz",
-            .hash = "N-V-__8AAGYqgADJ4CSWkkwZd12lq-o6Y9ByBpscPmS_tpH4",
-        },
-        .@"MoltenVK-macos" = .{
-            .url = "https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.0/MoltenVK-macos.tar",
-            .hash = "N-V-__8AAO62gwMuCOpZesC2YsUnsRFbbzsCigpvKBUl8QwB",
-        },
-        .@"Vulkan-Utility-Libraries" = .{
-            .url = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/v1.4.330.tar.gz",
-            .hash = "N-V-__8AAPKLeADUZQZzoYbObh2HUYR9pBncy2MDKFCCqtXz",
-        },
-        .@"SPIRV-Headers" = .{
-            .url = "https://github.com/KhronosGroup/SPIRV-Headers/archive/6bb105b6c4b3a246e1e6bb96366fe14c6dbfde83.tar.gz",
-            .hash = "N-V-__8AAP75OgDs2RQmQLAddfjvhD4RXblO1kSMg0ZvpCC1",
-        },
-        .@"Vulkan-ValidationLayers" = .{
-            .url = "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/v1.4.330.tar.gz",
-            .hash = "N-V-__8AAHvZ7QLIOvinD_aUpUBYF-rgwHYY6ZQXNHcltRfd",
-        },
-    },
+	.name = .cubyz_libs,
+	.fingerprint = 0x309b84abf3e7800f,
+	.version = "0.0.0",
+	.paths = .{""},
+	.dependencies = .{
+		.glfw = .{
+			.url = "https://github.com/glfw/glfw/archive/refs/tags/3.4.tar.gz",
+			.hash = "N-V-__8AAL40TADEbrysYHBl-UIZO4KiG4chP8pLDVDINGH4",
+		},
+		.harfbuzz = .{
+			.url = "https://github.com/harfbuzz/harfbuzz/archive/refs/tags/8.2.2.tar.gz",
+			.hash = "N-V-__8AAMnvlQXSfQ493UdwXL4VBQdgWMtBZJM2016lE2ns",
+		},
+		.freetype = .{
+			.url = "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
+			.hash = "N-V-__8AAKLKpwC4H27Ps_0iL3bPkQb-z6ZVSrB-x_3EEkub",
+		},
+		.glslang = .{
+			.url = "https://github.com/Games-by-Mason/glslang-zig/archive/cf74b30857e349c819c1c34ec717d4c9fc0eec5c.tar.gz",
+			.hash = "glslang-1.4.309-eMn68KLGCQDAuHVUzugaYOOEhbkyHmN526R7mHIq9YUs",
+		},
+		.@"Vulkan-Headers" = .{
+			.url = "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.330.tar.gz",
+			.hash = "N-V-__8AAFXYAQKsK51AAGXB9HziPDFjS_DVUq6_QHVxHrBM",
+		},
+		.@"Vulkan-Loader" = .{
+			.url = "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.4.330.tar.gz",
+			.hash = "N-V-__8AAGYqgADJ4CSWkkwZd12lq-o6Y9ByBpscPmS_tpH4",
+		},
+		.@"MoltenVK-macos" = .{
+			.url = "https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.0/MoltenVK-macos.tar",
+			.hash = "N-V-__8AAO62gwMuCOpZesC2YsUnsRFbbzsCigpvKBUl8QwB",
+		},
+		.@"Vulkan-Utility-Libraries" = .{
+			.url = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/v1.4.330.tar.gz",
+			.hash = "N-V-__8AAPKLeADUZQZzoYbObh2HUYR9pBncy2MDKFCCqtXz",
+		},
+		.@"SPIRV-Headers" = .{
+			.url = "https://github.com/KhronosGroup/SPIRV-Headers/archive/6bb105b6c4b3a246e1e6bb96366fe14c6dbfde83.tar.gz",
+			.hash = "N-V-__8AAP75OgDs2RQmQLAddfjvhD4RXblO1kSMg0ZvpCC1",
+		},
+		.@"Vulkan-ValidationLayers" = .{
+			.url = "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/v1.4.330.tar.gz",
+			.hash = "N-V-__8AAHvZ7QLIOvinD_aUpUBYF-rgwHYY6ZQXNHcltRfd",
+		},
+	},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,17 +20,29 @@
             .url = "https://github.com/Games-by-Mason/glslang-zig/archive/cf74b30857e349c819c1c34ec717d4c9fc0eec5c.tar.gz",
             .hash = "glslang-1.4.309-eMn68KLGCQDAuHVUzugaYOOEhbkyHmN526R7mHIq9YUs",
         },
-        .vulkanheaders = .{
+        .@"Vulkan-Headers" = .{
             .url = "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.330.tar.gz",
             .hash = "N-V-__8AAFXYAQKsK51AAGXB9HziPDFjS_DVUq6_QHVxHrBM",
         },
-        .vulkanloader = .{
+        .@"Vulkan-Loader" = .{
             .url = "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.4.330.tar.gz",
             .hash = "N-V-__8AAGYqgADJ4CSWkkwZd12lq-o6Y9ByBpscPmS_tpH4",
         },
-        .moltenv_macos = .{
+        .@"MoltenVK-macos" = .{
             .url = "https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.0/MoltenVK-macos.tar",
             .hash = "N-V-__8AAO62gwMuCOpZesC2YsUnsRFbbzsCigpvKBUl8QwB",
+        },
+        .@"Vulkan-Utility-Libraries" = .{
+            .url = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/v1.4.330.tar.gz",
+            .hash = "N-V-__8AAPKLeADUZQZzoYbObh2HUYR9pBncy2MDKFCCqtXz",
+        },
+        .@"SPIRV-Headers" = .{
+            .url = "https://github.com/KhronosGroup/SPIRV-Headers/archive/6bb105b6c4b3a246e1e6bb96366fe14c6dbfde83.tar.gz",
+            .hash = "N-V-__8AAP75OgDs2RQmQLAddfjvhD4RXblO1kSMg0ZvpCC1",
+        },
+        .@"Vulkan-ValidationLayers" = .{
+            .url = "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/v1.4.330.tar.gz",
+            .hash = "N-V-__8AAHvZ7QLIOvinD_aUpUBYF-rgwHYY6ZQXNHcltRfd",
         },
     },
 }

--- a/tools/file_replace.zig
+++ b/tools/file_replace.zig
@@ -1,6 +1,9 @@
 // NOTE(blackedout): Modified from https://ziglang.org/learn/build-system/#project-tools (2025-10-29)
+// Both the input and the output file will be present in memory simultaneously and entirely at some point,
+// so calling this for extremely large files might be a bad idea.
 
 const std = @import("std");
+const panic = std.debug.panic;
 
 const usage =
 	\\Usage: ./file_replace pattern replacement file
@@ -52,5 +55,5 @@ pub fn main() !void {
 }
 
 fn fatal(comptime format: []const u8, args: anytype) noreturn {
-	std.debug.panic(format, args);
+	panic(format, args);
 }

--- a/tools/file_replace.zig
+++ b/tools/file_replace.zig
@@ -1,0 +1,124 @@
+// NOTE(blackedout): Modified from https://ziglang.org/learn/build-system/#project-tools (2025-10-29)
+// This program should not be used for many occurrences of patterns (with short length) as each pattern invokes two file writes.
+
+const std = @import("std");
+
+const usage =
+	\\Usage: ./file_replace pattern replacement file
+;
+
+pub fn main() !void {
+	var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+	defer arena_state.deinit();
+	const arena = arena_state.allocator();
+
+	const args = try std.process.argsAlloc(arena);
+
+	var optPattern: ?[]const u8 = null;
+	var optReplacement: ?[]const u8 = null;
+	var optFilePath: ?[]const u8 = null;
+
+	{
+		var i: usize = 1;
+		while(i < args.len) : (i += 1) {
+			const arg = args[i];
+			if(std.mem.eql(u8, "-h", arg) or std.mem.eql(u8, "--help", arg)) {
+				try std.fs.File.stdout().writeAll(usage);
+				return std.process.cleanExit();
+			} else if(i == 1) {
+				optPattern = args[i];
+			} else if(i == 2) {
+				optReplacement = args[i];
+			} else if(i == 3) {
+				optFilePath = args[i];
+			} else {
+				fatal("superfluous arg: '{s}'", .{arg});
+			}
+		}
+	}
+
+	const pattern = optPattern orelse fatal("missing pattern", .{});
+	if(pattern.len == 0) {
+		fatal("pattern is empty (not allowed)", .{});
+	}
+	const replacement = optReplacement orelse fatal("missing replacement", .{});
+	const filePath = optFilePath orelse fatal("missing file", .{});
+
+	const outputFilePathSuffix = ".tmp";
+	const tmpOutputFilePathLength = filePath.len + outputFilePathSuffix.len;
+	var outputFilePath = arena.alloc(u8, tmpOutputFilePathLength) catch fatal("path allocation failed", .{});
+	defer arena.free(outputFilePath);
+	std.mem.copyForwards(u8, outputFilePath[0..filePath.len], filePath);
+	std.mem.copyForwards(u8, outputFilePath[filePath.len..], outputFilePathSuffix);
+
+	{
+		var inputFile = std.fs.cwd().openFile(filePath, .{}) catch |err| {
+			fatal("unable to open '{s}': {s}", .{filePath, @errorName(err)});
+		};
+		defer inputFile.close();
+
+		const inputFileStat = inputFile.stat() catch fatal("retrieving file size failed", .{});
+		if(inputFileStat.size > 1024*1024*1024) {
+			fatal("file too large (must not be larger than 1 GiB)", .{});
+		}
+
+		const buffer = std.heap.page_allocator.alloc(u8, inputFileStat.size) catch fatal("file buffer allocation failed", .{});
+		defer std.heap.page_allocator.free(buffer);
+		const readByteCount = inputFile.readAll(buffer) catch |err| {
+			fatal("file reading failed: {s}", .{@errorName(err)});
+		};
+		if(readByteCount != inputFileStat.size) {
+			fatal("file reading failed", .{});
+		}
+
+		if(std.fs.cwd().access(outputFilePath, .{.mode = .read_write})) |_| {
+			fatal("tmp output file '{s}' does already exist", .{outputFilePath});
+		} else |_| {}
+
+		const outputFile = std.fs.cwd().createFile(outputFilePath, .{}) catch |err| {
+			fatal("unable to open '{s}' for write: {s}", .{outputFilePath, @errorName(err)});
+		};
+		defer outputFile.close();
+
+		// NOTE(blackedout): Match the pattern, if complete, write block before pattern, then replacement.
+		// Finally write remaining block
+		var matchLength: u64 = 0;
+		var lastWriteEnd: u64 = 0;
+		var index: u64 = 0;
+		while(index < inputFileStat.size) : (index += 1) {
+			if(buffer[index] == pattern[matchLength]) {
+				matchLength += 1;
+
+				if(matchLength >= pattern.len) {
+					outputFile.writeAll(buffer[lastWriteEnd..(index + 1 - pattern.len)]) catch |err| {
+						fatal("file writing failed: {s}", .{@errorName(err)});
+					};
+					outputFile.writeAll(replacement) catch |err| {
+						fatal("file writing failed: {s}", .{@errorName(err)});
+					};
+					lastWriteEnd = index + 1;
+					matchLength = 0;
+				}
+			} else {
+				matchLength = 0;
+			}
+		}
+		outputFile.writeAll(buffer[lastWriteEnd..inputFileStat.size]) catch |err| {
+			fatal("file writing failed: {s}", .{@errorName(err)});
+		};
+	}
+
+	std.fs.cwd().deleteFile(filePath) catch |err| {
+		fatal("deleting input file failed: {s}", .{@errorName(err)});
+	};
+	std.fs.cwd().rename(outputFilePath, filePath) catch |err| {
+		fatal("renaming temporary file failed: {s}", .{@errorName(err)});
+	};
+
+	return std.process.cleanExit();
+}
+
+fn fatal(comptime format: []const u8, args: anytype) noreturn {
+	std.debug.print(format, args);
+	std.process.exit(1);
+}

--- a/tools/file_replace.zig
+++ b/tools/file_replace.zig
@@ -1,5 +1,4 @@
 // NOTE(blackedout): Modified from https://ziglang.org/learn/build-system/#project-tools (2025-10-29)
-// This program should not be used for many occurrences of patterns (with short length) as each pattern invokes two file writes.
 
 const std = @import("std");
 
@@ -13,103 +12,42 @@ pub fn main() !void {
 	const arena = arena_state.allocator();
 
 	const args = try std.process.argsAlloc(arena);
-
-	var optPattern: ?[]const u8 = null;
-	var optReplacement: ?[]const u8 = null;
-	var optFilePath: ?[]const u8 = null;
-
-	{
-		var i: usize = 1;
-		while(i < args.len) : (i += 1) {
-			const arg = args[i];
-			if(std.mem.eql(u8, "-h", arg) or std.mem.eql(u8, "--help", arg)) {
-				try std.fs.File.stdout().writeAll(usage);
-				return std.process.cleanExit();
-			} else if(i == 1) {
-				optPattern = args[i];
-			} else if(i == 2) {
-				optReplacement = args[i];
-			} else if(i == 3) {
-				optFilePath = args[i];
-			} else {
-				fatal("superfluous arg: '{s}'", .{arg});
-			}
-		}
+	if(args.len != 4) {
+		try std.fs.File.stdout().writeAll(usage);
+		return std.process.cleanExit();
 	}
 
-	const pattern = optPattern orelse fatal("missing pattern", .{});
+	const pattern = args[1];
 	if(pattern.len == 0) {
 		fatal("pattern is empty (not allowed)", .{});
 	}
-	const replacement = optReplacement orelse fatal("missing replacement", .{});
-	const filePath = optFilePath orelse fatal("missing file", .{});
+	const replacement = args[2];
+	const filePath = args[3];
 
-	const outputFilePathSuffix = ".tmp";
-	const tmpOutputFilePathLength = filePath.len + outputFilePathSuffix.len;
-	var outputFilePath = arena.alloc(u8, tmpOutputFilePathLength) catch fatal("path allocation failed", .{});
+	const outputFilePath = std.mem.concat(arena, u8, &.{filePath, ".tmp"}) catch |err| {
+		fatal("path allocation failed: {s}", .{@errorName(err)});
+	};
 	defer arena.free(outputFilePath);
-	std.mem.copyForwards(u8, outputFilePath[0..filePath.len], filePath);
-	std.mem.copyForwards(u8, outputFilePath[filePath.len..], outputFilePathSuffix);
 
-	{
-		var inputFile = std.fs.cwd().openFile(filePath, .{}) catch |err| {
-			fatal("unable to open '{s}': {s}", .{filePath, @errorName(err)});
-		};
-		defer inputFile.close();
+	if(std.fs.cwd().access(outputFilePath, .{.mode = .read_write})) |_| {
+		fatal("tmp output file '{s}' does already exist", .{outputFilePath});
+	} else |_| {}
 
-		const inputFileStat = inputFile.stat() catch fatal("retrieving file size failed", .{});
-		if(inputFileStat.size > 1024*1024*1024) {
-			fatal("file too large (must not be larger than 1 GiB)", .{});
-		}
+	const fileContents = std.fs.cwd().readFileAlloc(std.heap.page_allocator, filePath, 1024*1024*1024) catch |err| switch(err) {
+		error.FileTooBig => fatal("file too large (must not be larger than 1 GiB)", .{}),
+		else => fatal("file reading failed: {s}", .{@errorName(err)}),
+	};
+	defer std.heap.page_allocator.free(fileContents);
 
-		const buffer = std.heap.page_allocator.alloc(u8, inputFileStat.size) catch fatal("file buffer allocation failed", .{});
-		defer std.heap.page_allocator.free(buffer);
-		const readByteCount = inputFile.readAll(buffer) catch |err| {
-			fatal("file reading failed: {s}", .{@errorName(err)});
-		};
-		if(readByteCount != inputFileStat.size) {
-			fatal("file reading failed", .{});
-		}
+	const replacedSize = std.mem.replacementSize(u8, fileContents, pattern, replacement);
+	const replacementBuffer = std.heap.page_allocator.alloc(u8, replacedSize) catch |err| {
+		fatal("memory allocation failed: {s}", .{@errorName(err)});
+	};
+	defer std.heap.page_allocator.free(replacementBuffer);
+	_ = std.mem.replace(u8, fileContents, pattern, replacement, replacementBuffer);
 
-		if(std.fs.cwd().access(outputFilePath, .{.mode = .read_write})) |_| {
-			fatal("tmp output file '{s}' does already exist", .{outputFilePath});
-		} else |_| {}
-
-		const outputFile = std.fs.cwd().createFile(outputFilePath, .{}) catch |err| {
-			fatal("unable to open '{s}' for write: {s}", .{outputFilePath, @errorName(err)});
-		};
-		defer outputFile.close();
-
-		// NOTE(blackedout): Match the pattern, if complete, write block before pattern, then replacement.
-		// Finally write remaining block
-		var matchLength: u64 = 0;
-		var lastWriteEnd: u64 = 0;
-		var index: u64 = 0;
-		while(index < inputFileStat.size) : (index += 1) {
-			if(buffer[index] == pattern[matchLength]) {
-				matchLength += 1;
-
-				if(matchLength >= pattern.len) {
-					outputFile.writeAll(buffer[lastWriteEnd..(index + 1 - pattern.len)]) catch |err| {
-						fatal("file writing failed: {s}", .{@errorName(err)});
-					};
-					outputFile.writeAll(replacement) catch |err| {
-						fatal("file writing failed: {s}", .{@errorName(err)});
-					};
-					lastWriteEnd = index + 1;
-					matchLength = 0;
-				}
-			} else {
-				matchLength = 0;
-			}
-		}
-		outputFile.writeAll(buffer[lastWriteEnd..inputFileStat.size]) catch |err| {
-			fatal("file writing failed: {s}", .{@errorName(err)});
-		};
-	}
-
-	std.fs.cwd().deleteFile(filePath) catch |err| {
-		fatal("deleting input file failed: {s}", .{@errorName(err)});
+	std.fs.cwd().writeFile(.{.sub_path = outputFilePath, .data = replacementBuffer}) catch |err| {
+		fatal("file writing failed: {s}", .{@errorName(err)});
 	};
 	std.fs.cwd().rename(outputFilePath, filePath) catch |err| {
 		fatal("renaming temporary file failed: {s}", .{@errorName(err)});
@@ -119,6 +57,6 @@ pub fn main() !void {
 }
 
 fn fatal(comptime format: []const u8, args: anytype) noreturn {
-	std.debug.print(format, args);
+	std.debug.panic(format, args);
 	std.process.exit(1);
 }


### PR DESCRIPTION
This adds the Vulkan-Headers and Vulkan-Loader repositories (both v1.4.330) and the MoltenVK binaries (v1.4.0 for macOS) as dependencies to the `build.zig.zon`. All of these are only to be used on macOS for now, on other platforms the Vulkan headers are included with glad, the loader is expected to be present and MoltenVK is just for Apple platforms anyways.

The Vulkan loader gets built into the `cubyz_deps_*` file only if the target is macOS. The zig build code for this is a very incomplete version of the CMakeLists of the Vulkan-Loader repository but somehow enough to make it work.
And because I like calling zig with just `zig` as a globally installed version, the `build.zig` file was upgraded to use zig 0.15.1 (the latest version with brew right now).

The MoltenVK library and manifest files are copied into the lib directory of the zig output and instead of the glad Vulkan header files, the ones of the Vulkan-Headers repository are installed on macOS. This last thing is also important because some symbols needed (it is possible without too but makes the code prettier) on macOS are not defined in of Vulkan 1.0, which the glad generator was set to here I think.

Edit 2025-10-27
Now it also adds the Vulkan-Utility-Libraries and Vulkan-ValidationLayers (both v1.4.330) and SPIRV-Headers (latest) as dependencies to build the validation layer (only on macOS). The dylib and manifest files are also copied in the lib directory of the zig output. Like for the Vulkan loader it's just enough to make it work, not all CMakeLists functionality was implemented.
Also I tried to make all dependencies use v1.4.330, however the SPIRV-Headers don't have that tag yet so I just chose the latest commit. Additionally, the build uses headers from SPIRV-Tools and links against it via the glslang dependency, which has an even more outdated version. Probably not ideal but not exactly sure how this should be handled. Downgrade every dependency to the glslang version?